### PR TITLE
Enable SelectionLayer to select any layer without supplying layerIds

### DIFF
--- a/docs/api-reference/layers/selection-layer.md
+++ b/docs/api-reference/layers/selection-layer.md
@@ -81,6 +81,8 @@ Either `rectangle` or `polygon`
 
 Called when selection is completed.
 
-#### `layerIds` (String[], required)
+#### `layerIds` (String[], optional)
 
-Array of layer ids where we will search.
+- Default: `null`
+
+Array of layer ids where we will search. If not specified, then all pickable and visible layers are searched.

--- a/modules/layers/src/layers/selection-layer.ts
+++ b/modules/layers/src/layers/selection-layer.ts
@@ -25,14 +25,14 @@ const MODE_CONFIG_MAP = {
 };
 
 interface SelectionLayerProps<DataT> extends CompositeLayerProps<DataT> {
-  layerIds: any[];
+  layerIds: any[] | null;
   onSelect: (info: any) => any;
   selectionType: string | null;
 }
 
 const defaultProps: DefaultProps<SelectionLayerProps<any>> = {
   selectionType: SELECTION_TYPE.RECTANGLE,
-  layerIds: [],
+  layerIds: null,
   onSelect: () => {},
 };
 
@@ -124,12 +124,22 @@ export default class SelectionLayer<DataT, ExtraPropsT> extends CompositeLayer<
 
     // HACK, find a better way
     setTimeout(() => {
+      let selectionLayerIds = layerIds;
+      if (!selectionLayerIds) {
+        // Provide all visible and pickable layers to pickObjects when layerIds is not provided.
+        selectionLayerIds = this.context.layerManager
+          .getLayers()
+          .filter((layer) => layer.props.pickable && layer.props.visible)
+          .map((layer) => layer.props.id);
+      }
+
+      // @ts-ignore
       const pickingInfos = this.context.deck.pickObjects({
         x,
         y,
         width: maxX - x,
         height: maxY - y,
-        layerIds: [blockerId, ...layerIds],
+        layerIds: [blockerId, ...selectionLayerIds],
       });
 
       onSelect({


### PR DESCRIPTION
One issue I ran into with the SelectionLayer was that I had to supply all the layer IDs to it. As I'm creating layers dynamically and adding them asynchronously, passing an initial list into SelectionLayer wasn't feasible, and using a ref to Deck didn't work either.

In DeckGL, passing in layerIds to pickObjects is optional, resulting in all visible and pickable layers to be selected (https://deck.gl/docs/api-reference/core/deck#pickobjects).

This PR aligns the behaviour of the SelectionLayer with pickObjects, adding the ability to select any layers without passing in a layerIds array.