### PR TITLE
Update turf-difference from ^4.0.0 to ^6.2.0

### DIFF
--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -58,7 +58,7 @@
     "@turf/centroid": ">=4.0.0",
     "@turf/circle": ">=4.0.0",
     "@turf/destination": ">=4.0.0",
-    "@turf/difference": ">=4.0.0",
+    "@turf/difference": ">=6.2.0",
     "@turf/distance": ">=4.0.0",
     "@turf/ellipse": ">=4.0.0",
     "@turf/helpers": ">=4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2798,6 +2798,15 @@
     "@turf/meta" "6.x"
     martinez-polygon-clipping "*"
 
+"@turf/difference@>=6.2.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.5.0.tgz#677b0d5641a93bba2e82f2c683f0d880105b3197"
+  integrity sha512-l8iR5uJqvI+5Fs6leNbhPY5t/a3vipUF/3AeVLpwPQcgmedNXyheYuy07PcMGH5Jdpi5gItOiTqwiU/bUH4b3A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+    polygon-clipping "^0.15.3"
+
 "@turf/distance@6.x", "@turf/distance@>=4.0.0":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-6.0.1.tgz"
@@ -10454,6 +10463,13 @@ pn@^1.1.0:
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz"
   integrity sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==
 
+polygon-clipping@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/polygon-clipping/-/polygon-clipping-0.15.3.tgz#0215840438470ba2e9e6593625e4ea5c1087b4b7"
+  integrity sha512-ho0Xx5DLkgxRx/+n4O74XyJ67DcyN3Tu9bGYKsnTukGAW6ssnuak6Mwcyb1wHy9MZc9xsUWqIoiazkZB5weECg==
+  dependencies:
+    splaytree "^3.1.0"
+
 portfinder@^1.0.25:
   version "1.0.25"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.25.tgz"
@@ -11982,6 +11998,11 @@ spdy@^4.0.1:
 splaytree@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-0.1.4.tgz"
+
+splaytree@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/splaytree/-/splaytree-3.1.1.tgz#e1bc8e68e64ef5a9d5f09d36e6d9f3621795a438"
+  integrity sha512-9FaQ18FF0+sZc/ieEeXHt+Jw2eSpUgUtTLDYB/HXKWvhYVyOc7h1hzkn5MMO3GPib9MmXG1go8+OsBBzs/NMww==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
Updates turf-difference to ^6.2.0 where an improvement to the polygon-clipping algorithm was made - https://github.com/Turfjs/turf/blob/master/CHANGELOG.md#620

This addresses:
- Correctness issues in polygon clipping, which affects the accuracy of polygon selection.
- I also observed it to address the exception thrown with self-intersecting polygons that results in polygon selection effectively becoming a rectangle selection (referenced here: https://github.com/uber/nebula.gl/blob/1af2f9ca28c8481d46770a2582bec8685cbcf7c5/modules/layers/src/layers/selection-layer.ts#L114)

Usage of turf-difference in the layers module is unaffected by breaking changes made in 5.0 of turf (https://github.com/Turfjs/turf/blob/master/CHANGELOG.md#500-), with no relevant breaking changes made in 6.0.